### PR TITLE
(general): Resolve server hitches by preventing consecutive xPlayer loops; (legacy): Use GetExtendedPlayers() instead of GetPlayers()

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -170,9 +170,15 @@ end)
 ESX.RegisterServerCallback('esx_society:getEmployees', function(source, cb, society)
 	local employees = {}
 
-	local xPlayers = ESX.GetPlayers()
-	for k, v in pairs(xPlayers) do
-		local xPlayer = ESX.GetPlayerFromId(v)
+	local xPlayers
+	if ESX.GetExtendedPlayers then	
+		xPlayers = ESX.GetExtendedPlayers()		-- Retrieve all xPlayer data directly (ESX Legacy)
+	else
+		xPlayers = ESX.GetPlayers()				-- Retrieves player ids and gets xPlayer data one-by-one (ESX 1.2 support)
+	end
+	
+	for k,v in pairs(xPlayers) do
+		local xPlayer = type(v) ~= 'table' and v or ESX.GetPlayerFromId(k)
 
 		local name = GetPlayerName(xPlayer.source)
 		if Config.EnableESXIdentity then
@@ -301,10 +307,16 @@ ESX.RegisterServerCallback('esx_society:setJobSalary', function(source, cb, job,
 				['@grade']    = grade
 			}, function(rowsChanged)
 				Jobs[job].grades[tostring(grade)].salary = salary
-				local xPlayers = ESX.GetPlayers()
 
-				for i=1, #xPlayers, 1 do
-					local xTarget = ESX.GetPlayerFromId(xPlayers[i])
+				local xPlayers
+				if ESX.GetExtendedPlayers then	
+					xPlayers = ESX.GetExtendedPlayers()		-- Retrieve all xPlayer data directly (ESX Legacy)
+				else
+					xPlayers = ESX.GetPlayers()				-- Retrieves player ids and gets xPlayer data one-by-one (ESX 1.2 support)
+				end
+				
+				for k,v in pairs(xPlayers) do
+					local xTarget = type(v) ~= 'table' and v or ESX.GetPlayerFromId(k)
 
 					if xTarget.job.name == job and xTarget.job.grade == grade then
 						xTarget.setJob(job, grade)
@@ -324,11 +336,17 @@ ESX.RegisterServerCallback('esx_society:setJobSalary', function(source, cb, job,
 end)
 
 ESX.RegisterServerCallback('esx_society:getOnlinePlayers', function(source, cb)
-	local xPlayers = ESX.GetPlayers()
 	local players = {}
 
-	for i=1, #xPlayers, 1 do
-		local xPlayer = ESX.GetPlayerFromId(xPlayers[i])
+	local xPlayers
+	if ESX.GetExtendedPlayers then	
+		xPlayers = ESX.GetExtendedPlayers()		-- Retrieve all xPlayer data directly (ESX Legacy)
+	else
+		xPlayers = ESX.GetPlayers()				-- Retrieves player ids and gets xPlayer data one-by-one (ESX 1.2 support)
+	end
+	
+	for k,v in pairs(xPlayers) do
+		local xPlayer = type(v) ~= 'table' and v or ESX.GetPlayerFromId(k)
 		table.insert(players, {
 			source = xPlayer.source,
 			identifier = xPlayer.identifier,

--- a/server/main.lua
+++ b/server/main.lua
@@ -178,7 +178,7 @@ ESX.RegisterServerCallback('esx_society:getEmployees', function(source, cb, soci
 	end
 	
 	for k,v in pairs(xPlayers) do
-		local xPlayer = type(v) == 'table' and v or ESX.GetPlayerFromId(k)
+		local xPlayer = type(v) == 'table' and v or ESX.GetPlayerFromId(v)
 
 		local name = GetPlayerName(xPlayer.source)
 		if Config.EnableESXIdentity then
@@ -316,7 +316,7 @@ ESX.RegisterServerCallback('esx_society:setJobSalary', function(source, cb, job,
 				end
 				
 				for k,v in pairs(xPlayers) do
-					local xTarget = type(v) == 'table' and v or ESX.GetPlayerFromId(k)
+					local xTarget = type(v) == 'table' and v or ESX.GetPlayerFromId(v)
 
 					if xTarget.job.name == job and xTarget.job.grade == grade then
 						xTarget.setJob(job, grade)
@@ -346,7 +346,8 @@ ESX.RegisterServerCallback('esx_society:getOnlinePlayers', function(source, cb)
 	end
 	
 	for k,v in pairs(xPlayers) do
-		local xPlayer = type(v) == 'table' and v or ESX.GetPlayerFromId(k)
+		local xPlayer = type(v) == 'table' and v or ESX.GetPlayerFromId(v)
+		
 		table.insert(players, {
 			source = xPlayer.source,
 			identifier = xPlayer.identifier,

--- a/server/main.lua
+++ b/server/main.lua
@@ -3,6 +3,7 @@ local Jobs = {}
 local RegisteredSocieties = {}
 
 TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)
+local isLegacy = not not ESX.GetExtendedPlayers
 
 function GetSociety(name)
 	for i=1, #RegisteredSocieties, 1 do
@@ -170,13 +171,7 @@ end)
 ESX.RegisterServerCallback('esx_society:getEmployees', function(source, cb, society)
 	local employees = {}
 
-	local xPlayers
-	if ESX.GetExtendedPlayers then	
-		xPlayers = ESX.GetExtendedPlayers()		-- Retrieve all xPlayer data directly (ESX Legacy)
-	else
-		xPlayers = ESX.GetPlayers()				-- Retrieves player ids and gets xPlayer data one-by-one (ESX 1.2 support)
-	end
-	
+	local xPlayers = isLegacy and ESX.GetExtendedPlayers() or ESX.GetPlayers()
 	for k,v in pairs(xPlayers) do
 		local xPlayer = type(v) == 'table' and v or ESX.GetPlayerFromId(v)
 
@@ -308,13 +303,7 @@ ESX.RegisterServerCallback('esx_society:setJobSalary', function(source, cb, job,
 			}, function(rowsChanged)
 				Jobs[job].grades[tostring(grade)].salary = salary
 
-				local xPlayers
-				if ESX.GetExtendedPlayers then	
-					xPlayers = ESX.GetExtendedPlayers()		-- Retrieve all xPlayer data directly (ESX Legacy)
-				else
-					xPlayers = ESX.GetPlayers()				-- Retrieves player ids and gets xPlayer data one-by-one (ESX 1.2 support)
-				end
-				
+				local xPlayers = isLegacy and ESX.GetExtendedPlayers() or ESX.GetPlayers()
 				for k,v in pairs(xPlayers) do
 					local xTarget = type(v) == 'table' and v or ESX.GetPlayerFromId(v)
 
@@ -341,13 +330,8 @@ local onlinePlayers = {}
 ESX.RegisterServerCallback('esx_society:getOnlinePlayers', function(source, cb)
 	if getOnlinePlayers == false and next(onlinePlayers) == nil then	-- Prevent multiple xPlayer loops from running in quick succession
 		getOnlinePlayers, onlinePlayers = true, {}
-		local xPlayers
-		if not ESX.GetExtendedPlayers then	
-			xPlayers = ESX.GetExtendedPlayers()		-- Retrieve all xPlayer data directly (ESX Legacy)
-		else
-			xPlayers = ESX.GetPlayers()				-- Retrieves player ids and gets xPlayer data one-by-one (ESX 1.2 support)
-		end
-
+		
+		local xPlayers = isLegacy and ESX.GetExtendedPlayers() or ESX.GetPlayers()
 		for k,v in pairs(xPlayers) do
 			local xPlayer = type(v) == 'table' and v or ESX.GetPlayerFromId(v)
 			

--- a/server/main.lua
+++ b/server/main.lua
@@ -178,7 +178,7 @@ ESX.RegisterServerCallback('esx_society:getEmployees', function(source, cb, soci
 	end
 	
 	for k,v in pairs(xPlayers) do
-		local xPlayer = type(v) ~= 'table' and v or ESX.GetPlayerFromId(k)
+		local xPlayer = type(v) == 'table' and v or ESX.GetPlayerFromId(k)
 
 		local name = GetPlayerName(xPlayer.source)
 		if Config.EnableESXIdentity then
@@ -316,7 +316,7 @@ ESX.RegisterServerCallback('esx_society:setJobSalary', function(source, cb, job,
 				end
 				
 				for k,v in pairs(xPlayers) do
-					local xTarget = type(v) ~= 'table' and v or ESX.GetPlayerFromId(k)
+					local xTarget = type(v) == 'table' and v or ESX.GetPlayerFromId(k)
 
 					if xTarget.job.name == job and xTarget.job.grade == grade then
 						xTarget.setJob(job, grade)
@@ -346,7 +346,7 @@ ESX.RegisterServerCallback('esx_society:getOnlinePlayers', function(source, cb)
 	end
 	
 	for k,v in pairs(xPlayers) do
-		local xPlayer = type(v) ~= 'table' and v or ESX.GetPlayerFromId(k)
+		local xPlayer = type(v) == 'table' and v or ESX.GetPlayerFromId(k)
 		table.insert(players, {
 			source = xPlayer.source,
 			identifier = xPlayer.identifier,


### PR DESCRIPTION
Prevent multiple xPlayer loops from running in quick succession by forcing other requests to wait for the first loop to finish and returning its result.
For ESX Legacy this will also use the new ESX.GetExtendedPlayers() function which basically kills the hitches by itself.


<img src='https://i.imgur.com/JfXSmns.png'/>